### PR TITLE
feat: materialize records v2

### DIFF
--- a/examples/reader.js
+++ b/examples/reader.js
@@ -2,15 +2,17 @@
 const parquet = require('..');
 
 async function example() {
-  let reader = await parquet.ParquetReader.openFile('fruits.parquet');
-
+  let reader = await parquet.ParquetReader.openFile('parquet_memory_limit-21mb.parquet');
+  let count =0
   let cursor = reader.getCursor();
   let record = null;
   while (record = await cursor.next()) {
-    console.log(record);
+    count++
+    
   }
 
   reader.close();
+  console.log(count);
 }
 
 example();

--- a/examples/readerV2.js
+++ b/examples/readerV2.js
@@ -1,0 +1,22 @@
+'use strict';
+const parquet = require('..');
+
+async function readerV2(){
+
+    let reader = await parquet.ParquetReader.openFile('parquet_memory_limit-21mb.parquet')
+    let cursor = reader.getCursor();
+    let count = 0
+    for(let index=0; index<reader.envelopeReader.metadata.row_groups.length;index++){
+      console.log({index})
+        for await (const _row of cursor.nextByRowGroups(index)) {
+            console.log({
+                _row
+            })
+            count++
+     }
+
+    }
+    console.log(count);
+
+  }
+readerV2()  

--- a/lib/reader.ts
+++ b/lib/reader.ts
@@ -85,6 +85,16 @@ class ParquetCursor  {
     return this.rowGroup[this.cursorIndex++];
   }
 
+  async * nextByRowGroups(index: number) {
+    const buffer = await this.envelopeReader.readRowGroup(this.schema, this.metadata.row_groups[index], this.columnList)
+    for (const row of parquet_shredder.materializeRecordsV2(this.schema, buffer,  parseInt(this.metadata.row_groups[index].num_rows.toString()))) {
+        yield row
+      }
+      await new Promise((resolve)=>{
+      setTimeout(()=>resolve('success'), 3000)
+      })
+}
+
   /**
    * Rewind the cursor to the beginning of the file
    */

--- a/lib/shred.ts
+++ b/lib/shred.ts
@@ -241,7 +241,7 @@ export const materializeRecordsV2 = function * (schema: ParquetSchema, buffer: R
           
           const field = schema.findField(k);
           const fieldBranch = schema.findFieldBranch(k);
-          let values3 = columnValues[k].values
+          let values = columnValues[k].values
           let rLevels = new Array(field.rLevelMax + 1);
           rLevels.fill(0);
 
@@ -253,7 +253,7 @@ export const materializeRecordsV2 = function * (schema: ParquetSchema, buffer: R
           
           let value = null;
           if (dLevel === field.dLevelMax) {
-              value = parquet_types.fromPrimitive(field.originalType || field.primitiveType, values3.next().value);
+              value = parquet_types.fromPrimitive(field.originalType || field.primitiveType, values.next().value);
           }
           records[rLevels[0] - 1]= records[rLevels[0] - 1] || {};
           materializeRecordField(records[rLevels[0] - 1], fieldBranch, rLevels.slice(1), dLevel, value);


### PR DESCRIPTION
Problem
=======
Ao ler um arquivo parquet de 175 colunas e com quase 500 mil linhas, a memoria pode chegar até 6 gb.

Solution
========
Visto que poderia ter memory leak, foi criado uma materialização que trabalhe e leia linha a linha o buffer do readRowGroup, tambem foi desacoplado a leitura por agrupamento e deixando 3 segundos de delay para leitura entre um agrupamento e outro, assim deixando a leitura por agrupamento fora da lib, esses ajustes resultou em uma redução de memoria de até 4,5gb.
